### PR TITLE
Updated build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,16 @@ repositories {
         name = "MaxanierMaven"
         url = "https://maxanier.de/maven2"
     }
+    maven {
+        // location of the maven that hosts JEI files
+        name = "Progwml6 maven"
+        url = "http://dvs1.progwml6.com/files/maven"
+    }
+    maven {
+        // location of a maven mirror for JEI files, as a fallback
+        name = "ModMaven"
+        url = "modmaven.k-4u.nl"
+    }
 }
 dependencies {
     //compile against the Vampirism API


### PR DESCRIPTION
Vampirism required JEI as a dependency, so make sure to add the repos for JEI (and fallback)